### PR TITLE
Singleplayer Initial Commit

### DIFF
--- a/AVRmada/AVRmada.cproj
+++ b/AVRmada/AVRmada.cproj
@@ -28,6 +28,18 @@
     <ResetRule>0</ResetRule>
     <eraseonlaunchrule>0</eraseonlaunchrule>
     <EraseKey />
+    <AsfFrameworkConfig>
+      <framework-data xmlns="">
+  <options />
+  <configurations />
+  <files />
+  <documentation help="" />
+  <offline-documentation help="" />
+  <dependencies>
+    <content-extension eid="atmel.asf" uuidref="Atmel.ASF" version="3.52.0" />
+  </dependencies>
+</framework-data>
+    </AsfFrameworkConfig>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <ToolchainSettings>
@@ -70,43 +82,43 @@
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
     <ToolchainSettings>
       <AvrGcc>
-  <avrgcc.common.Device>-mmcu=atmega328p -B "%24(PackRepoDir)\atmel\ATmega_DFP\1.7.374\gcc\dev\atmega328p"</avrgcc.common.Device>
-  <avrgcc.common.outputfiles.hex>True</avrgcc.common.outputfiles.hex>
-  <avrgcc.common.outputfiles.lss>True</avrgcc.common.outputfiles.lss>
-  <avrgcc.common.outputfiles.eep>True</avrgcc.common.outputfiles.eep>
-  <avrgcc.common.outputfiles.srec>True</avrgcc.common.outputfiles.srec>
-  <avrgcc.common.outputfiles.usersignatures>False</avrgcc.common.outputfiles.usersignatures>
-  <avrgcc.compiler.general.ChangeDefaultCharTypeUnsigned>True</avrgcc.compiler.general.ChangeDefaultCharTypeUnsigned>
-  <avrgcc.compiler.general.ChangeDefaultBitFieldUnsigned>True</avrgcc.compiler.general.ChangeDefaultBitFieldUnsigned>
-  <avrgcc.compiler.symbols.DefSymbols>
-    <ListValues>
-      <Value>DEBUG</Value>
-    </ListValues>
-  </avrgcc.compiler.symbols.DefSymbols>
-  <avrgcc.compiler.directories.IncludePaths>
-    <ListValues>
-      <Value>%24(PackRepoDir)\atmel\ATmega_DFP\1.7.374\include\</Value>
-      <Value>../include</Value>
-      <Value>../src</Value>
-    </ListValues>
-  </avrgcc.compiler.directories.IncludePaths>
-  <avrgcc.compiler.optimization.level>Optimize most (-O3)</avrgcc.compiler.optimization.level>
-  <avrgcc.compiler.optimization.PackStructureMembers>True</avrgcc.compiler.optimization.PackStructureMembers>
-  <avrgcc.compiler.optimization.AllocateBytesNeededForEnum>True</avrgcc.compiler.optimization.AllocateBytesNeededForEnum>
-  <avrgcc.compiler.optimization.DebugLevel>Default (-g2)</avrgcc.compiler.optimization.DebugLevel>
-  <avrgcc.compiler.warnings.AllWarnings>True</avrgcc.compiler.warnings.AllWarnings>
-  <avrgcc.linker.libraries.Libraries>
-    <ListValues>
-      <Value>libm</Value>
-    </ListValues>
-  </avrgcc.linker.libraries.Libraries>
-  <avrgcc.assembler.general.IncludePaths>
-    <ListValues>
-      <Value>%24(PackRepoDir)\atmel\ATmega_DFP\1.7.374\include\</Value>
-    </ListValues>
-  </avrgcc.assembler.general.IncludePaths>
-  <avrgcc.assembler.debugging.DebugLevel>Default (-Wa,-g)</avrgcc.assembler.debugging.DebugLevel>
-</AvrGcc>
+        <avrgcc.common.Device>-mmcu=atmega328p -B "%24(PackRepoDir)\atmel\ATmega_DFP\1.7.374\gcc\dev\atmega328p"</avrgcc.common.Device>
+        <avrgcc.common.outputfiles.hex>True</avrgcc.common.outputfiles.hex>
+        <avrgcc.common.outputfiles.lss>True</avrgcc.common.outputfiles.lss>
+        <avrgcc.common.outputfiles.eep>True</avrgcc.common.outputfiles.eep>
+        <avrgcc.common.outputfiles.srec>True</avrgcc.common.outputfiles.srec>
+        <avrgcc.common.outputfiles.usersignatures>False</avrgcc.common.outputfiles.usersignatures>
+        <avrgcc.compiler.general.ChangeDefaultCharTypeUnsigned>True</avrgcc.compiler.general.ChangeDefaultCharTypeUnsigned>
+        <avrgcc.compiler.general.ChangeDefaultBitFieldUnsigned>True</avrgcc.compiler.general.ChangeDefaultBitFieldUnsigned>
+        <avrgcc.compiler.symbols.DefSymbols>
+          <ListValues>
+            <Value>DEBUG</Value>
+          </ListValues>
+        </avrgcc.compiler.symbols.DefSymbols>
+        <avrgcc.compiler.directories.IncludePaths>
+          <ListValues>
+            <Value>%24(PackRepoDir)\atmel\ATmega_DFP\1.7.374\include\</Value>
+            <Value>../include</Value>
+            <Value>../src</Value>
+          </ListValues>
+        </avrgcc.compiler.directories.IncludePaths>
+        <avrgcc.compiler.optimization.level>Optimize most (-O3)</avrgcc.compiler.optimization.level>
+        <avrgcc.compiler.optimization.PackStructureMembers>True</avrgcc.compiler.optimization.PackStructureMembers>
+        <avrgcc.compiler.optimization.AllocateBytesNeededForEnum>True</avrgcc.compiler.optimization.AllocateBytesNeededForEnum>
+        <avrgcc.compiler.optimization.DebugLevel>Default (-g2)</avrgcc.compiler.optimization.DebugLevel>
+        <avrgcc.compiler.warnings.AllWarnings>True</avrgcc.compiler.warnings.AllWarnings>
+        <avrgcc.linker.libraries.Libraries>
+          <ListValues>
+            <Value>libm</Value>
+          </ListValues>
+        </avrgcc.linker.libraries.Libraries>
+        <avrgcc.assembler.general.IncludePaths>
+          <ListValues>
+            <Value>%24(PackRepoDir)\atmel\ATmega_DFP\1.7.374\include\</Value>
+          </ListValues>
+        </avrgcc.assembler.general.IncludePaths>
+        <avrgcc.assembler.debugging.DebugLevel>Default (-Wa,-g)</avrgcc.assembler.debugging.DebugLevel>
+      </AvrGcc>
     </ToolchainSettings>
   </PropertyGroup>
   <ItemGroup>
@@ -116,6 +128,9 @@
     <Compile Include="include\gfx.h">
       <SubType>compile</SubType>
     </Compile>
+    <Compile Include="include\singleplayer.h">
+      <SubType>compile</SubType>
+    </Compile>
     <Compile Include="src\battleship_utils.c">
       <SubType>compile</SubType>
     </Compile>
@@ -123,6 +138,9 @@
       <SubType>compile</SubType>
     </Compile>
     <Compile Include="src\main.c">
+      <SubType>compile</SubType>
+    </Compile>
+    <Compile Include="src\singleplayer.c">
       <SubType>compile</SubType>
     </Compile>
   </ItemGroup>

--- a/AVRmada/include/singleplayer.h
+++ b/AVRmada/include/singleplayer.h
@@ -1,0 +1,18 @@
+#ifndef SINGLEPLAYER_H
+#define SINGLEPLAYER_H
+
+#include "battleship_utils.h"
+#include <stdint.h>
+#include <stdbool.h>
+
+/*  Reset any internal state before every new single?player game */
+void sp_reset(void);
+
+void sp_tick(void);
+
+/*  Called from main.c instead of sending real UART traffic */
+void sp_on_tx_ready(uint16_t self_token);
+void sp_on_tx_attack(uint8_t row, uint8_t col);
+void sp_on_tx_result(uint8_t row, uint8_t col, bool hit);   /* (unused for now) */
+
+#endif /* SINGLEPLAYER_H */

--- a/AVRmada/src/main.c
+++ b/AVRmada/src/main.c
@@ -16,6 +16,7 @@
 
 #include "gfx.h"
 #include "battleship_utils.h"
+#include "singleplayer.h"
 
 /* -------------------------------------------------------------------------
  *  GLOBAL GAME STATE
@@ -69,21 +70,6 @@ static uint16_t resendTick = 0;		   // ms since last packet sent
 static uint16_t postReadyLeft = 0;		 // How long to keep sending READY after sync
 
 /* -------------------------------------------------------------------------
- *  PROTOCOL TRANSMISSION HELPERS
- * ------------------------------------------------------------------------- */
-static inline void tx_ready(void) {
-	printf("READY %u\n", selfToken);
-}
-
-static inline void tx_attack(uint8_t r, uint8_t c) {
-	printf("A %u %u\n", r, c);
-}
-
-static inline void tx_result(uint8_t r, uint8_t c, bool hit) {
-	printf("R %u %u %c\n", r, c, hit ? 'H' : 'M');
-}
-
-/* -------------------------------------------------------------------------
  *  GAME STATES
  * ------------------------------------------------------------------------- */
 
@@ -113,6 +99,36 @@ static enum {
 	NS_WAIT_RES,
 	NS_GAME_OVER
 } nState;
+
+/* -------------------------------------------------------------------------
+ *  PROTOCOL TRANSMISSION HELPERS
+ * ------------------------------------------------------------------------- */
+static inline void tx_ready(void) {
+	if (gMode == GM_SINGLEPLAYER) {
+		sp_on_tx_ready(selfToken);
+	} else {
+		 printf("READY %u\n", selfToken);
+	}
+}
+
+static inline void tx_attack(uint8_t r, uint8_t c) {
+	if (gMode == GM_SINGLEPLAYER) {
+		sp_on_tx_attack(r, c);
+	} else {
+		printf("A %u %u\n", r, c);
+	}      
+}
+
+static inline void tx_result(uint8_t r, uint8_t c, bool hit) {
+	if (gMode == GM_SINGLEPLAYER) {
+		sp_on_tx_result(r, c, hit);
+	} else {
+		printf("R %u %u %c\n", r, c, hit ? 'H' : 'M');
+	}    
+}
+
+// Singleplayer Override
+void net_inject_line(const char *line);
 
 /* -------------------------------------------------------------------------
  *  GAME STATE HANDLERS
@@ -330,6 +346,7 @@ static void handle_main_menu(void) {
  *  START A NEW GAME - DRAW THE BOARD
  * ------------------------------------------------------------------------- */
 static void handle_new_game(void) {
+	if (gMode == GM_SINGLEPLAYER) sp_reset();
 	gui_draw_placement();
 	gState = GS_PLACING;
 }
@@ -561,6 +578,23 @@ static void handle_over(void) {
 }
 
 /* -------------------------------------------------------------------------
+ *  SINGLEPLAYER HELPERS
+ * ------------------------------------------------------------------------- */
+
+/* -------------------------------------------------------------------------
+ *  Helper for single?player mode – lets the AI push a complete line straight
+ *  into the normal RX parser (avoids touching the UART layer).
+ * ------------------------------------------------------------------------- */
+void net_inject_line(const char *line)
+{
+    /* parse_line expects a writable buffer – make a local copy */
+    char tmp[RX_MAX];
+    strncpy(tmp, line, RX_MAX - 1);
+    tmp[RX_MAX - 1] = '\0';
+    parse_line(tmp);
+}
+
+/* -------------------------------------------------------------------------
  *  MAIN FUNCTION
  * ------------------------------------------------------------------------- */
 /**
@@ -625,6 +659,9 @@ int main(void) {
 				handle_over();
 				break;
 		}
+		
+		/* Flush one queued spoofed packet (single?player only) */
+		if (gMode == GM_SINGLEPLAYER) sp_tick();
 
 		_delay_ms(1);   // Tick every 1 ms
 		systemTime++;   // Advance system time counter

--- a/AVRmada/src/singleplayer.c
+++ b/AVRmada/src/singleplayer.c
@@ -1,0 +1,65 @@
+#include "singleplayer.h"
+#include <string.h>
+#include <stdio.h>
+
+extern void net_inject_line(const char *line);
+
+/* ------------------------------------------------------------------ */
+/* Simple circular queue of pending lines to inject on the next tick  */
+/* ------------------------------------------------------------------ */
+#define QCAP 4
+static char  qbuf[QCAP][32];
+static uint8_t qhead = 0, qtail = 0;
+
+static inline bool q_full (void) { return (uint8_t)(qhead + 1) % QCAP == qtail; }
+static inline bool q_empty(void) { return qhead == qtail; }
+
+static void q_push(const char *s)
+{
+	if (q_full()) return;          /* drop if ever over?run – harmless here */
+	strncpy(qbuf[qhead], s, 31);
+	qbuf[qhead][31] = '\0';
+	qhead = (uint8_t)(qhead + 1) % QCAP;
+}
+
+/* PUBLIC ------------------------------------------------------------------ */
+
+void sp_reset(void)
+{
+	qhead = qtail = 0;
+}
+
+void sp_tick(void)
+{
+	if (q_empty()) return;
+	net_inject_line(qbuf[qtail]);
+	qtail = (uint8_t)(qtail + 1) % QCAP;
+}
+
+/* ------------- spoofed TX helpers --------------------------------------- */
+
+void sp_on_tx_ready(uint16_t self_token)
+{
+	char line[32];
+	snprintf(line, sizeof(line), "READY %u", 1);   /* static peer token = 1 */
+	q_push(line);
+}
+
+void sp_on_tx_attack(uint8_t row, uint8_t col)
+{
+	char line[32];
+
+	/* 1) send RESULT (always miss) */
+	snprintf(line, sizeof(line), "R %u %u M", row, col);
+	q_push(line);
+
+	/* 2) opponent fires back at same square */
+	snprintf(line, sizeof(line), "A %u %u", row, col);
+	q_push(line);
+}
+
+void sp_on_tx_result(uint8_t row, uint8_t col, bool hit)
+{
+	/* not used by echo AI – ignore */
+	(void)row; (void)col; (void)hit;
+}


### PR DESCRIPTION
  - Added initial singleplayer logic to 'spoof' UART network traffic
  - This strategy allows us to reuse almost all of our game logic without needing too much separate logic for singleplayer mode.
  - This singleplayer mode just echos back the attack from a player, however the AI has no enemy ships or guessing algorithms or anything.